### PR TITLE
Support streams for templated emails

### DIFF
--- a/email.go
+++ b/email.go
@@ -33,7 +33,7 @@ type Email struct {
 	Attachments []Attachment `json:",omitempty"`
 	// Metadata: metadata
 	Metadata map[string]string `json:",omitempty"`
-	// MessageStream: metadata
+	// MessageStream: Set message stream ID that's used for sending. If not provided, message will default to the outbound transactional stream.
 	MessageStream string `json:",omitempty"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/keighl/postmark
+
+go 1.15
+
+require goji.io v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+goji.io v1.1.0 h1:7QNQWwPiGPyOlpH9UDNh+F9BdGMLXr60lfvPSnigA8o=
+goji.io v2.0.2+incompatible h1:uIssv/elbKRLznFUy3Xj4+2Mz/qKhek/9aZQDUMae7c=
+goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMIk=

--- a/templates.go
+++ b/templates.go
@@ -201,6 +201,8 @@ type TemplatedEmail struct {
 	TrackOpens bool `json:",omitempty"`
 	// Attachments: List of attachments
 	Attachments []Attachment `json:",omitempty"`
+	// MessageStream: Set message stream ID that's used for sending. If not provided, message will default to the outbound transactional stream.
+	MessageStream string `json:",omitempty"`
 }
 
 // SendTemplatedEmail sends an email using a template (TemplateId)


### PR DESCRIPTION
Allow us to send out templated broadcasts

Note: The upstream remote appears to be unmaintained, so I am not PRing this upstream.